### PR TITLE
add support for stm32l4

### DIFF
--- a/MODBUS-LIB/Src/Modbus.c
+++ b/MODBUS-LIB/Src/Modbus.c
@@ -1468,7 +1468,7 @@ if(modH->xTypeHW != TCP_HW)
         ulTaskNotifyTake(pdTRUE, 250); //wait notification from TXE interrupt
 
 
-#if defined(STM32H745xx) || defined(STM32H743xx)  || defined(STM32F303xE)
+#if defined(STM32H745xx) || defined(STM32H743xx)  || defined(STM32F303xE) || defined(STM32L4)
           while((modH->port->Instance->ISR & USART_ISR_TC) ==0 )
 #else
           while((modH->port->Instance->SR & USART_SR_TC) ==0 )


### PR DESCRIPTION
STM32L4 can be supported by simply adding it to the `#if defined`.
Should work for all L4s, but only tested on L496 (as USART master and slave with and without RS485).