### PR TITLE
to fix describle mHandlers[] variable issues

### DIFF
--- a/MODBUS-LIB/Inc/Modbus.h
+++ b/MODBUS-LIB/Inc/Modbus.h
@@ -231,7 +231,7 @@ enum
 
 
 
-modbusHandler_t *mHandlers[MAX_M_HANDLERS];
+extern modbusHandler_t *mHandlers[MAX_M_HANDLERS];
 
 // Function prototypes
 void ModbusInit(modbusHandler_t * modH);

--- a/MODBUS-LIB/Inc/Modbus.h
+++ b/MODBUS-LIB/Inc/Modbus.h
@@ -242,8 +242,8 @@ void ModbusStartCDC(modbusHandler_t * modH);
 #endif
 
 void setTimeOut( uint16_t u16timeOut); //!<write communication watch-dog timer
-uint16_t getTimeOut(); //!<get communication watch-dog timer value
-bool getTimeOutState(); //!<get communication watch-dog timer state
+uint16_t getTimeOut(void); //!<get communication watch-dog timer value
+bool getTimeOutState(void); //!<get communication watch-dog timer state
 void ModbusQuery(modbusHandler_t * modH, modbus_t telegram ); // put a query in the queue tail
 void ModbusQueryInject(modbusHandler_t * modH, modbus_t telegram); //put a query in the queue head
 void StartTaskModbusSlave(void *argument); //slave

--- a/MODBUS-LIB/Src/Modbus.c
+++ b/MODBUS-LIB/Src/Modbus.c
@@ -33,8 +33,7 @@
 #define lowByte(w) ((w) & 0xff)
 #define highByte(w) ((w) >> 8)
 
-
-
+modbusHandler_t *mHandlers[MAX_M_HANDLERS];
 
 ///Queue Modbus telegrams for master
 const osMessageQueueAttr_t QueueTelegram_attributes = {

--- a/MODBUS-LIB/Src/UARTCallback.c
+++ b/MODBUS-LIB/Src/UARTCallback.c
@@ -139,7 +139,7 @@ void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t Size)
 	    		{
 	    			if(Size) //check if we have received any byte
 	    			{
-		    				mHandlers[i]->xBufferRX.u8available = Size;
+						mHandlers[i]->xBufferRX.u8available = (uint8_t)Size;
 		    				mHandlers[i]->xBufferRX.overflow = false;
 
 		    				while(HAL_UARTEx_ReceiveToIdle_DMA(mHandlers[i]->port, mHandlers[i]->xBufferRX.uxBuffer, MAX_BUFFER) != HAL_OK)


### PR DESCRIPTION
we should to add 'extern' for mHandlers[] in header files
to keep only instance of mHandlers[] in Modbus.c
