### PR TITLE
add missing defines to ModbusConfig.h

### DIFF
--- a/Examples/ModbusH743TCP/Core/Inc/ModbusConfig.h
+++ b/Examples/ModbusH743TCP/Core/Inc/ModbusConfig.h
@@ -26,6 +26,12 @@
 #define MAX_M_HANDLERS 2    //Maximum number of modbus handlers that can work concurrently
 #define MAX_TELEGRAMS 2     //Max number of Telegrams in master queue
 
+// Values copied from the ModbusF429TCP example project.
+#define NUMBERTCPCONN   4   // Maximum number of simultaneous client connections, it should be equal or less than LWIP configuration
+#define TCPAGINGCYCLES	1000 // Number of times the master will check for a incoming request before closing the connection for inactivity
+/* Note: the total aging time for a connection is approximately NUMBERTCPCONN*TCPAGINGCYCLES*u16timeOut ticks
+ * for the values selected in this example it is approximately 40 seconds
+*/
 
 
 


### PR DESCRIPTION
Thank You for creating this project.

When trying MODBUS TCP on the NUCLEO-H743ZI board, I noticed, that the `ModbusH743TCP` project doesn't compile due to missing defines. 
I simply copied the `ModbusConfig.h` content from the `ModbusF429TCP` example project and everything ran fine on the Nucelo baord.

With this simple fix, your Modbus743TCP project, can be compiled again.