### PR TITLE
Tested/Added functionality for STM32WB series

### DIFF
--- a/MODBUS-LIB/Src/Modbus.c
+++ b/MODBUS-LIB/Src/Modbus.c
@@ -1569,7 +1569,7 @@ if(modH->xTypeHW != TCP_HW)
 * USART datasheet and add the corresponding family in the following
 * preprocessor conditions
 */
-#if defined(STM32H7)  || defined(STM32F3) || defined(STM32L4) || defined(STM32L082xx) || defined(STM32F7)
+#if defined(STM32H7)  || defined(STM32F3) || defined(STM32L4) || defined(STM32L082xx) || defined(STM32F7) || defined(STM32WB)
           while((modH->port->Instance->ISR & USART_ISR_TC) ==0 )
 #else
           // F429, F103, L152 ...


### PR DESCRIPTION
Modified the "Modbus.c" file to include "stm32wbxx_hal.h" to add support for STM32WB series. Tested on STM32WB55. Specifically tested as a slave device with DMA enabled.