### PR TITLE
Fix incorrect timing between data frames

### DIFF
--- a/MODBUS-LIB/Src/Modbus.c
+++ b/MODBUS-LIB/Src/Modbus.c
@@ -1091,6 +1091,12 @@ void StartTaskModbusMaster(void *argument)
    	   ulNotificationValue = ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
      }
 #else
+     /*Wait period of silence between modbus frame */
+	 if(modH->port->Init.BaudRate <= 19200)
+	 	osDelay((int)(35000/modH->port->Init.BaudRate) + 2);
+	 else
+	 	osDelay(3);
+
      // This is the case for implementations with only USART support
      SendQuery(modH, telegram);
      /* Block indefinitely until a Modbus Frame arrives or query timeouts*/


### PR DESCRIPTION
Library makes an insufficient period of silence between messages in modbus rtu master mode.
This fix calculates the required delay after sending the previous message based on the UART bus baudrate.
(only for ENABLE_TCP == 0 )
The delay between messages is selected according to the ModBus standard.

https://github.com/alejoseb/Modbus-STM32-HAL-FreeRTOS/issues/88