### PR TITLE
Flipped two lines in UARTCallback.c

### DIFF
--- a/MODBUS-LIB/Src/UARTCallback.c
+++ b/MODBUS-LIB/Src/UARTCallback.c
@@ -70,8 +70,8 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *UartHandle)
 
     		if(mHandlers[i]->xTypeHW == USART_HW)
     		{
-    			RingAdd(&mHandlers[i]->xBufferRX, mHandlers[i]->dataRX);
     			HAL_UART_Receive_IT(mHandlers[i]->port, &mHandlers[i]->dataRX, 1);
+			RingAdd(&mHandlers[i]->xBufferRX, mHandlers[i]->dataRX);
     			xTimerResetFromISR(mHandlers[i]->xTimerT35, &xHigherPriorityTaskWoken);
     		}
     		break;


### PR DESCRIPTION
Since there was always a wrong number of bytes received I looked at the implementation of the interrupt and found that some value was added to the ring buffer before the UART receive register was read. I flipped those two lines and now it works properly.