### PR TITLE
Fix modbus RTU write multipe coils (15) command

### DIFF
--- a/MODBUS-LIB/Src/Modbus.c
+++ b/MODBUS-LIB/Src/Modbus.c
@@ -1116,7 +1116,7 @@ int8_t SendQuery(modbusHandler_t *modH ,  modbus_t telegram )
 
 	    for (uint16_t i = 0; i < u8bytesno; i++)
 	    {
-	        if(i%2)
+	        if(i%2 == 0)
 	        {
 	        	modH->u8Buffer[ modH->u8BufferSize ] = lowByte( telegram.u16reg[ i/2 ] );
 	        }


### PR DESCRIPTION
There is issues when sending multiple coils (less than 8) on other devices (nothing is sent). Moreover, modbus RTU protocol clearly specifies little-endian order for coils bytes, which is violated in code and fixed by this pull request.
[Modbus specification](https://www.modbus.org/file/secure/modbusprotocolspecification.pdf), page 29
Seem to apply to both [Modbus TCP](https://www.modbus.org/file/secure/messagingimplementationguide.pdf) (see page 23) and Modbus RTU (only Modbus RTU was tested).