### PR TITLE
Fix FC15 byte count under-counting by one for 9-15 coils mod 16

### DIFF
--- a/MODBUS-LIB/Src/Modbus.c
+++ b/MODBUS-LIB/Src/Modbus.c
@@ -1055,7 +1055,7 @@ int8_t SendQuery(modbusHandler_t *modH ,  modbus_t telegram )
 {
 
 
-	uint8_t u8regsno, u8bytesno;
+	uint8_t u8bytesno;
 	uint8_t  error = 0;
 	xSemaphoreTake(modH->ModBusSphrHandle , portMAX_DELAY); //before processing the message get the semaphore
 
@@ -1101,13 +1101,7 @@ int8_t SendQuery(modbusHandler_t *modH ,  modbus_t telegram )
 	    modH->u8BufferSize = 6;
 	    break;
 	case MB_FC_WRITE_MULTIPLE_COILS: // TODO: implement "sending coils"
-	    u8regsno = telegram.u16CoilsNo / 16;
-	    u8bytesno = u8regsno * 2;
-	    if ((telegram.u16CoilsNo % 16) != 0)
-	    {
-	        u8bytesno++;
-	        u8regsno++;
-	    }
+	    u8bytesno = (telegram.u16CoilsNo + 7) / 8;   // ceil(N/8)
 
 	    modH->u8Buffer[ NB_HI ]      = highByte(telegram.u16CoilsNo );
 	    modH->u8Buffer[ NB_LO ]      = lowByte( telegram.u16CoilsNo );


### PR DESCRIPTION
SendQuery (MB_FC_WRITE_MULTIPLE_COILS) computed the data byte count in 16-coil units with a single +1 correction, so when coils % 16 fell in 9-15 the leftover needed two bytes but only one was added. BYTE_CNT was written one too small and the packing loop ran one iteration short, dropping the high byte of the last register (e.g. 9 coils dropped coil 8).

Replace with ceil(N/8), mirroring the idiom in process_FC1, and remove the now-unused u8regsno local.

Closes #134